### PR TITLE
Add integration with moulinette

### DIFF
--- a/module.json
+++ b/module.json
@@ -6,6 +6,7 @@
   "minimumCoreVersion": "0.6.5",
   "compatibleCoreVersion": "0.8.8",
   "author": "Tabletop RPG Music",
+  "scripts": ["scripts/tabletop-rpg-music.js"],
   "packs": [
     {
       "name": "tabletop-rpg-music",

--- a/scripts/tabletop-rpg-music.js
+++ b/scripts/tabletop-rpg-music.js
@@ -1,0 +1,11 @@
+Hooks.once("ready", async function () {
+    if (game.moulinette) {
+        game.moulinette.sources.push({
+            type: "sounds",
+            publisher: "Tabletop RPG Music",
+            pack: "Tabletop RPG Music",
+            source: "data",
+            path: "modules/tabletop-rpg-music/music",
+        });
+    }
+});


### PR DESCRIPTION
This makes it so that Tabletop RPG Music shows up in Moulinette as
```
Tabletop RPG Music | (40)
```
Usually, Moulinette has a structure of publishers and packages of those publishers, and packages are then listed as
```
publisher | package (number of elements)
```
However, it looks like it strips out the package name if it is equal to the publisher, which is what I did in this case. Do you have any other names that could / should be used as publisher of package? If so, I can adjust it accordingly to make it look a bit "nicer". But it's probably not that important, the integration also works perfectly fine as is :)